### PR TITLE
Fix firebase client initialization

### DIFF
--- a/firebase/client.ts
+++ b/firebase/client.ts
@@ -7,14 +7,14 @@ const firebaseConfig = {
   apiKey: "AIzaSyC4m1gY5HLIV2pXSmtCUyvyBLLh-mbZtEU",
   authDomain: "prepwise-d688e.firebaseapp.com",
   projectId: "prepwise-d688e",
-  storageBucket: "prepwise-d688e.firebasestorage.app",
+  storageBucket: "prepwise-d688e.appspot.com",
   messagingSenderId: "1062014699215",
   appId: "1:1062014699215:web:96bf3ac8bb9c86f475d9ba",
   measurementId: "G-J8S2QXDXLD"
 };
 
 // Initialize Firebase
-const app = !getApps.length ? initializeApp(firebaseConfig) : getApp();
+const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 
 export const auth = getAuth(app);
 export const db = getFirestore(app);


### PR DESCRIPTION
## Summary
- fix storageBucket name in firebase client config
- correctly check for existing apps before initializing Firebase

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481adb28888328b34faae88a660c01